### PR TITLE
Fix install docs for npm 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,10 @@ One command. Installs the skill to `~/.claude/commands/seed/` — available in e
 npm i -g @chrisai/seed
 
 # Install to current project only
-npm i -g @chrisai/seed -- --local
+npx @chrisai/seed --local
 
 # Custom Claude config directory
-npm i -g @chrisai/seed -- --config-dir /path/to/.claude
+npx @chrisai/seed --config-dir /path/to/.claude
 ```
 
 Then open Claude Code and type `/seed` to start.

--- a/README.md
+++ b/README.md
@@ -202,14 +202,14 @@ All integrations are additive. SEED works without any of them installed.
 ## Install
 
 ```bash
-npm i -g @chrisai/seed
+npx @chrisai/seed
 ```
 
 One command. Installs the skill to `~/.claude/commands/seed/` — available in every workspace.
 
 ```bash
 # Global install (default) — available everywhere
-npm i -g @chrisai/seed
+npx @chrisai/seed
 
 # Install to current project only
 npx @chrisai/seed --local


### PR DESCRIPTION
## Summary
- Replace `npm i -g @chrisai/seed` with `npx @chrisai/seed` for global install
- Replace `npm i -g @chrisai/seed -- --local` with `npx @chrisai/seed --local` for local install
- Replace `npm i -g @chrisai/seed -- --config-dir` with `npx @chrisai/seed --config-dir` for custom directory

## Problem
1. **Global install (Fixes #1):** `npm i -g @chrisai/seed` registers the `seed` binary but never runs the installer to copy files to `~/.claude/commands/seed/`. The package has no `postinstall` script, so `npm install` alone doesn't trigger the file copy.

2. **Local/custom install (npm 7+):** The `--` separator causes npm 7+ to treat `--local` and `--config-dir` as separate package names to install, resulting in a `404 Not Found` error. In npm 6, `--` forwarded arguments to lifecycle scripts, but this behavior was removed in npm 7.

## Fix
Use `npx @chrisai/seed` for all install methods, which directly executes the install script and correctly passes flags like `--local` and `--config-dir`.

## Tested
- `npx @chrisai/seed` — installs to `~/.claude/commands/seed/`
- `npx @chrisai/seed --local` — installs to `./.claude/commands/seed/` (project only)
- Verified no cross-contamination between global and local installs

🤖 Generated with [Claude Code](https://claude.com/claude-code)