### PR TITLE
docs: add direct npx install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ All integrations are additive. SEED works without any of them installed.
 
 ## Install
 
+### npm (global)
+
 ```bash
 npm i -g @chrisai/seed
 ```
@@ -223,6 +225,18 @@ npm i -g @chrisai/seed -- --local
 
 # Custom Claude config directory
 npm i -g @chrisai/seed -- --config-dir /path/to/.claude
+```
+
+### npx (no global install)
+
+Prefer not to install globally? Run it directly with `npx` — no prior install needed:
+
+```bash
+# Global install (default) — available everywhere
+npx @chrisai/seed
+
+# Install to current project only
+npx @chrisai/seed --local
 ```
 
 Then open Claude Code and type `/seed` to start.


### PR DESCRIPTION
## What

Adds an `npx` (no global install) example to the README install section, alongside the existing global `npm i -g @chrisai/seed` instructions.

## Why

The README documented only the global install. A direct `npx @chrisai/seed` example lets users run the installer without installing globally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
