### PR TITLE
fix: run installer automatically on global npm install

### DIFF
--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+// Skip if explicitly opted out
+if (process.env.SEED_SKIP_POSTINSTALL === '1') process.exit(0);
+
+// Only run automatically on global installs, not local/dependency installs
+if (!process.env.npm_config_global) process.exit(0);
+
+try {
+  require('./install.js');
+} catch (err) {
+  console.warn('\n  [seed] postinstall skipped:', err.message, '\n');
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@chrisai/seed",
   "version": "1.0.0",
+  "scripts": {
+    "postinstall": "node bin/postinstall.js"
+  },
   "description": "Typed project incubator — guided ideation through graduation for Claude Code. Part of the Agentic OS by Chris AI Systems.",
   "bin": {
     "seed": "bin/install.js"


### PR DESCRIPTION
Fixes #1

## Problem
`npm i -g @chrisai/seed` installs the binary but never runs it, so nothing gets copied to `~/.claude/commands/seed/`. The install appears to succeed but the `/seed` command is never available in Claude Code.

`npx @chrisai/seed` works because npx immediately executes the binary — `npm i -g` does not.

## Fix
- Added `bin/postinstall.js` — a guarded wrapper that only runs the installer on global installs, respects `SEED_SKIP_POSTINSTALL=1` to opt out, and wraps in try/catch so it never fails an npm install
- Added a `scripts.postinstall` entry in `package.json` pointing to `bin/postinstall.js`

## Testing
```bash
npm pack
sudo npm i -g ./chrisai-seed-1.0.0.tgz
ls ~/.claude/commands/seed/
# checklists  data  seed.md  tasks  templates
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
EOF
)"